### PR TITLE
Complete Dynamic Ambiguity Analysis

### DIFF
--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -380,7 +380,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                       then DynAmb.dummyIsolate >>> first Seq.singleton
                       else DynAmb.isolate
             defDynAmbKind = case target of
-              UnresolvableAmbiguity -> CompleteDyn
+              UnresolvableAmbiguity -> RaceDyn
               Ambiguity -> FastDyn
             fastAnalyze = DynAmb.analyze (-1) pl DynAmb.convertToken
             completeAnalyze = \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return

--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -111,9 +111,9 @@ test :: IO ()
 -- test = withArgs ["examples/ambig.syncon", "examples/ambig.test", "--dot=out"] main
 -- test = withArgs ["examples/ambig.syncon", "examples/ambig.test", "--two-level"] main
 -- test = withArgs ["examples/bootstrap.syncon", "--source=examples/bootstrap.syncon", "--json=out.json"] main
--- test = withArgs ["--help"] main
+test = withArgs ["--help"] main
 -- test = withArgs ["parse", "README.md", "source.test"] main
-test = withArgs ["pbt", "examples/ambig.syncon"] main
+-- test = withArgs ["pbt", "examples/ambig.syncon"] main
 -- test = withArgs ["compose", "examples/ambig.syncon"] main
 -- test = GLL.test
 
@@ -161,10 +161,11 @@ parseAction = do
     <> Opt.metavar "S"
     <> Opt.help "Timeout for attempting to parse a single source file, in seconds. A negative value means 'wait forever'."
     <> Opt.value (-1)
+  dynAmbKind <- dynOptFlag
   dynAmbTimeout <- fmap (*1_000) $ Opt.option Opt.auto
     $ Opt.long "dynamic-resolvability-timeout"
     <> Opt.metavar "MS"
-    <> Opt.help "Timeout for determining if a single ambiguity is resolvable, in milliseconds. A negative value means 'wait forever'."
+    <> Opt.help "Timeout for determining if a single ambiguity is resolvable, in milliseconds. A negative value means 'wait forever'. Only used by '--fast'."
     <> Opt.value 1_000
   noIsolation <- Opt.switch
     $ Opt.long "no-isolation"
@@ -184,6 +185,9 @@ parseAction = do
         isolate = if noIsolation
                   then DynAmb.dummyIsolate >>> first Seq.singleton
                   else DynAmb.isolate
+        analyze = case fromMaybe FastDyn dynAmbKind of
+          FastDyn -> DynAmb.analyze dynAmbTimeout pl DynAmb.convertToken
+          CompleteDyn -> \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
     srcNodes <- flip M.traverseWithKey sources $ \path _ -> do
       putStrLn $ "Parsing \"" <> path <> "\""
       handle (\(SourceFileException t) -> modifyIORef' failureFiles (+1) >> sourceFailureHandler t) $ do
@@ -206,7 +210,7 @@ parseAction = do
                     , DynAmb.tokRange = range
                     }
               in ambs
-                 & mapM (foldMap S.singleton >>> DynAmb.analyze dynAmbTimeout pl DynAmb.convertToken (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
+                 & mapM (foldMap S.singleton >>> analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
                  <&> fmap (formatError opts)
                  <&> formatErrors sources
                  >>= die'
@@ -260,6 +264,17 @@ compileCommand = Opt.command "compile" (Opt.info compileCmd $ Opt.progDesc "Comp
         (_, preParse, pl) <- compileAction precKind files
         let serialisable = (Parser.precomputeToSerialisable preParse, pl)
         writeFileSerialise outputFile serialisable
+
+data DynAnalysisKind = FastDyn | CompleteDyn
+dynOptFlag :: Opt.Parser (Maybe DynAnalysisKind)
+dynOptFlag = optional $ fast <|> complete
+  where
+    fast = Opt.flag' FastDyn
+      $ Opt.long "fast"
+      <> Opt.help "Use the fast dynamic analysis that might not terminate (except for timeout) on unresolvable input"
+    complete = Opt.flag' CompleteDyn
+      $ Opt.long "complete"
+      <> Opt.help "Use the complete dynamic analsis that will always terminate, but that might be very slow"
 
 parseCommand :: Opt.Mod Opt.CommandFields (IO ())
 parseCommand = Opt.command "parse" (Opt.info parseCmd $ Opt.progDesc "Parse a list of files using a compiled '.synconc' file.")
@@ -335,6 +350,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
         <> Opt.metavar "MS"
         <> Opt.help "Timeout before discarding a test case, in milliseconds. A negative value means 'wait forever'."
         <> Opt.value 4_000
+      dynAmbKind <- dynOptFlag
       showTwoLevel <- Opt.switch
         $ Opt.long "two-level"
         <> Opt.help "Always show the two level representation, even if some alternatives are resolvable."
@@ -354,6 +370,12 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
             isolate = if noIsolation
                       then DynAmb.dummyIsolate >>> first Seq.singleton
                       else DynAmb.isolate
+            defDynAmbKind = case target of
+              UnresolvableAmbiguity -> CompleteDyn
+              Ambiguity -> FastDyn
+            analyze = case fromMaybe defDynAmbKind dynAmbKind of
+              FastDyn -> DynAmb.analyze (-1) pl DynAmb.convertToken
+              CompleteDyn -> \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
         let gen = Parser.programGenerator df
             prop = Hedgehog.withDiscards (fromInteger numDiscards) $ Hedgehog.withTests (fromInteger numRuns) $ Hedgehog.property $ do
               (size, syncons, types, Lexer.makeFakeFile -> (sources, program)) <- Hedgehog.forAllWith ((\(_, _, _, x) -> x) >>> toList >>> fmap Forest.unlex >>> Text.intercalate " " >>> toS) gen
@@ -372,7 +394,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                     Data _ -> Hedgehog.success
                     Error ambs -> do
                       errs <- ambs
-                        & mapM (foldMap S.singleton >>> DynAmb.analyze (-1) pl DynAmb.convertToken (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
+                        & mapM (foldMap S.singleton >>> analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
                         <&> Seq.filter (hasAmbStyle target)
                         & lift
                       if Seq.null errs

--- a/syncon-parser/src/Data/Automaton/DVA.hs
+++ b/syncon-parser/src/Data/Automaton/DVA.hs
@@ -345,12 +345,6 @@ renumber = renumberStates >>> renumberStack
 
 mapKeys :: (Eq k2, Hashable k2) => (k1 -> k2) -> HashMap k1 v -> HashMap k2 v
 mapKeys convert = M.toList >>> fmap (first convert) >>> M.fromList
--- data NVA s sta i o c = NVA
---   { initial :: HashSet s
---   , innerTransitions :: HashMap s (HashMap i (HashSet s))
---   , openTransitions :: HashMap s (HashMap o (HashSet (sta, s)))
---   , closeTransitions :: HashMap s (HashMap c (HashSet (sta, s)))
---   , final :: HashSet s }
 
 asNVA :: ( Eq s, Hashable s
          , Eq sta, Hashable sta)

--- a/syncon-parser/src/Data/Automaton/NVA.hs
+++ b/syncon-parser/src/Data/Automaton/NVA.hs
@@ -34,6 +34,32 @@ data NVA s sta i o c = NVA
   deriving (Show, Eq, Generic)
 instance (Hashable s, Hashable sta, Hashable i, Hashable o, Hashable c) => Hashable (NVA s sta i o c)
 
+recognizes :: forall s sta i o c. (Eq s, Hashable s, Eq sta, Hashable sta, Eq i, Hashable i, Eq o, Hashable o, Eq c, Hashable c)
+           => NVA s sta i o c -> [TaggedTerminal i o c] -> Bool
+recognizes NVA{..} = recur (S.map (,[]) initial)
+  where
+    recur :: HashSet (s, [sta]) -> [TaggedTerminal i o c] -> Bool
+    recur configs [] = S.filter (snd >>> null) configs & S.map fst & any (`S.member` final)
+    recur configs _
+      | S.null configs = False
+    recur configs (c : str) = recur (foldMap (step c) configs) str
+
+    step :: TaggedTerminal i o c -> (s, [sta]) -> HashSet (s, [sta])
+    step (Inner i) (s, stack) = M.lookup s innerTransitions
+      >>= M.lookup i
+      & foldMap (S.map (, stack))
+    step (Open o) (s, stack) = M.lookup s openTransitions
+      >>= M.lookup o
+      & fold
+      & S.map (\(sta, s') -> (s', sta : stack))
+    step (Close _) (_, []) = S.empty
+    step (Close c) (s, sta : stack) = M.lookup s closeTransitions
+      >>= M.lookup c
+      & fold
+      & S.filter (fst >>> (== sta))
+      & S.map (\(_, s') -> (s', stack))
+
+
 -- | Retrieve all the states mentioned in an NVA
 states :: (Eq s, Hashable s) => NVA s sta i o c -> HashSet s
 states NVA{..} = initial `S.union` final `S.union` S.fromList (inners ++ opens ++ closes)

--- a/syncon-parser/syncon.cabal
+++ b/syncon-parser/syncon.cabal
@@ -218,7 +218,9 @@ test-suite syncon-parser-test
                , unordered-containers
                , filepath
                , directory
+               , hedgehog
   main-is: Main.hs
+  other-modules: ParseTest
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints

--- a/syncon-parser/syncon.cabal
+++ b/syncon-parser/syncon.cabal
@@ -221,6 +221,7 @@ test-suite syncon-parser-test
                , hedgehog
   main-is: Main.hs
   other-modules: ParseTest
+               , AutomataTest
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints

--- a/syncon-parser/syncon.cabal
+++ b/syncon-parser/syncon.cabal
@@ -219,6 +219,7 @@ test-suite syncon-parser-test
                , filepath
                , directory
                , hedgehog
+               , lifted-async
   main-is: Main.hs
   other-modules: ParseTest
                , AutomataTest

--- a/syncon-parser/test/AutomataTest.hs
+++ b/syncon-parser/test/AutomataTest.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE TemplateHaskell, RecordWildCards #-}
+
+module AutomataTest (test) where
+
+import Pre hiding (State)
+
+import Data.Automaton.EpsilonNVA (EpsNVA(EpsNVA), TaggedTerminal(..))
+import qualified Data.Automaton.EpsilonNVA as EpsNVA
+import Data.Automaton.NVA (NVA(NVA))
+import qualified Data.Automaton.NVA as NVA
+
+import qualified Data.HashSet as S
+import qualified Data.HashMap.Strict as M
+
+import Hedgehog hiding (test)
+import qualified Hedgehog.Gen as G
+import qualified Hedgehog.Range as R
+
+test :: IO Bool
+test = checkParallel $$(discover)
+
+data Sigma = A | B | C deriving (Eq, Show, Enum, Bounded, Generic)
+instance Hashable Sigma
+
+data State = P | Q | R | S | T deriving (Eq, Show, Enum, Bounded, Generic)
+instance Hashable State
+
+showStr :: (Show i, Show o, Show c) => [TaggedTerminal i o c] -> [Char]
+showStr = fmap fmt >>> intercalate " " >>> \case
+  [] -> "<empty>"
+  x -> x
+  where
+    fmt (Open o) = "<" <> show o
+    fmt (Close c) = show c <> ">"
+    fmt (Inner i) = show i
+
+gTaggedTerminal :: Gen (TaggedTerminal Sigma Sigma Sigma)
+gTaggedTerminal = G.choice
+  [ Inner <$> G.enumBounded
+  , Open <$> G.enumBounded
+  , Close <$> G.enumBounded
+  ]
+
+gStr :: Gen [TaggedTerminal Sigma Sigma Sigma]
+gStr = G.list (R.linear 0 10) gTaggedTerminal
+
+showEpsNVA :: (Show s, Show sta, Show i, Show o, Show c) => EpsNVA s sta i o c -> [Char]
+showEpsNVA EpsNVA{..} =
+  "initial: " <> intercalate ", " (show <$> toList initial) <> "\n"
+  <> "final: " <> intercalate ", " (show <$> toList final) <> "\n"
+  <> "trans:\n" <> intercalate "\n" (sort $ inners <> opens <> closes)
+  where
+    inners = EpsNVA.toTriples innerTransitions
+      <&> \(p, l, q) -> "  " <> show p <> " --  " <> maybe "_" show l <> "     --> " <> show q
+    opens = EpsNVA.toTriples openTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- <" <> show l <> ", +" <> show sta <> " --> " <> show q
+    closes = EpsNVA.toTriples closeTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
+
+showNVA :: (Show s, Show sta, Show i, Show o, Show c) => NVA s sta i o c -> [Char]
+showNVA NVA{..} =
+  "initial: " <> intercalate ", " (show <$> toList initial) <> "\n"
+  <> "final: " <> intercalate ", " (show <$> toList final) <> "\n"
+  <> "trans:\n" <> intercalate "\n" (sort $ inners <> opens <> closes)
+  where
+    inners = EpsNVA.toTriples innerTransitions
+      <&> \(p, l, q) -> "  " <> show p <> " --  " <> show l <> "     --> " <> show q
+    opens = EpsNVA.toTriples openTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- <" <> show l <> ", +" <> show sta <> " --> " <> show q
+    closes = EpsNVA.toTriples closeTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
+
+gEps :: Gen (EpsNVA State Sigma Sigma Sigma Sigma)
+gEps = do
+  initial <- G.subsequence [P ..] & G.filter (null >>> not) <&> S.fromList
+  final <- G.subsequence [P ..] <&> S.fromList
+  innerTransitions <- (,,) <$> G.enumBounded <*> G.maybe G.enumBounded <*> G.enumBounded
+    & G.list (R.linear 0 10)
+    <&> EpsNVA.fromTriples
+  openTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> EpsNVA.fromTriples
+  closeTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> EpsNVA.fromTriples
+  pure EpsNVA{..}
+
+gNVA :: Gen (NVA State Sigma Sigma Sigma Sigma)
+gNVA = do
+  initial <- G.subsequence [P ..] & G.filter (null >>> not) <&> S.fromList
+  final <- G.subsequence [P ..] <&> S.fromList
+  innerTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> G.enumBounded
+    & G.list (R.linear 0 10)
+    <&> NVA.fromTriples
+  openTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> NVA.fromTriples
+  closeTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> NVA.fromTriples
+  pure NVA{..}
+
+-- TODO: better printing of automata and strings (and fix the intentional bug in EpsNVA.recognizes
+
+prop_EpsToNVACorrectBroad :: Property
+prop_EpsToNVACorrectBroad = withTests 10000 $ property $ do
+  enva <- forAllWith showEpsNVA gEps
+  let nva = NVA.fromEpsNVA enva
+  annotate $ showNVA nva
+  str <- forAllWith showStr gStr
+  let erec = EpsNVA.recognizes enva str
+      nrec = NVA.recognizes nva str
+  classify "any matches" $ erec || nrec
+  erec === nrec
+
+prop_trivCoReduceCorrect :: Property
+prop_trivCoReduceCorrect = withTests 10000 $ property $ do
+  nva <- forAllWith showNVA gNVA
+  let nva' = NVA.trivialCoReduce nva
+  annotate $ showNVA nva'
+  str <- forAllWith showStr gStr
+  let r = NVA.recognizes nva str
+      r' = NVA.recognizes nva' str
+  classify "any matches" $ r || r'
+  r === r'
+
+prop_ReduceCorrect :: Property
+prop_ReduceCorrect = withTests 10000 $ property $ do
+  nva <- forAllWith showNVA gNVA
+  let nva' = NVA.reduce nva
+  annotate $ showNVA nva'
+  str <- forAllWith showStr gStr
+  let r = NVA.recognizes nva str
+      r' = NVA.recognizes nva' str
+  classify "any matches" $ r || r'
+  r === r'

--- a/syncon-parser/test/AutomataTest.hs
+++ b/syncon-parser/test/AutomataTest.hs
@@ -2,17 +2,22 @@
 
 module AutomataTest (test) where
 
-import Pre hiding (State)
+import Pre hiding (State, race, diff)
+
+import Control.Concurrent.Async.Lifted (race)
 
 import Data.Automaton.EpsilonNVA (EpsNVA(EpsNVA), TaggedTerminal(..))
 import qualified Data.Automaton.EpsilonNVA as EpsNVA
 import Data.Automaton.NVA (NVA(NVA))
 import qualified Data.Automaton.NVA as NVA
+import Data.Automaton.DVA (DVA(DVA))
+import qualified Data.Automaton.DVA as DVA
 
 import qualified Data.HashSet as S
 import qualified Data.HashMap.Strict as M
 
 import Hedgehog hiding (test)
+import qualified Hedgehog
 import qualified Hedgehog.Gen as G
 import qualified Hedgehog.Range as R
 
@@ -24,6 +29,20 @@ instance Hashable Sigma
 
 data State = P | Q | R | S | T deriving (Eq, Show, Enum, Bounded, Generic)
 instance Hashable State
+
+discardSlow :: Int -> Hedgehog.TestT IO a -> Hedgehog.PropertyT IO a
+discardSlow timelimit v = do
+  result <- Hedgehog.test $ race (liftIO $ threadDelay timelimit) v
+  case result of
+    Left _ -> discard
+    Right a -> pure a
+
+failSlow :: Int -> Hedgehog.TestT IO a -> Hedgehog.PropertyT IO a
+failSlow timelimit v = do
+  result <- Hedgehog.test $ race (liftIO $ threadDelay timelimit) v
+  case result of
+    Left _ -> failure
+    Right a -> pure a
 
 showStr :: (Show i, Show o, Show c) => [TaggedTerminal i o c] -> [Char]
 showStr = fmap fmt >>> intercalate " " >>> \case
@@ -57,19 +76,6 @@ showEpsNVA EpsNVA{..} =
     closes = EpsNVA.toTriples closeTransitions
       <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
 
-showNVA :: (Show s, Show sta, Show i, Show o, Show c) => NVA s sta i o c -> [Char]
-showNVA NVA{..} =
-  "initial: " <> intercalate ", " (show <$> toList initial) <> "\n"
-  <> "final: " <> intercalate ", " (show <$> toList final) <> "\n"
-  <> "trans:\n" <> intercalate "\n" (sort $ inners <> opens <> closes)
-  where
-    inners = EpsNVA.toTriples innerTransitions
-      <&> \(p, l, q) -> "  " <> show p <> " --  " <> show l <> "     --> " <> show q
-    opens = EpsNVA.toTriples openTransitions
-      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- <" <> show l <> ", +" <> show sta <> " --> " <> show q
-    closes = EpsNVA.toTriples closeTransitions
-      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
-
 gEps :: Gen (EpsNVA State Sigma Sigma Sigma Sigma)
 gEps = do
   initial <- G.subsequence [P ..] & G.filter (null >>> not) <&> S.fromList
@@ -85,6 +91,19 @@ gEps = do
     <&> EpsNVA.fromTriples
   pure EpsNVA{..}
 
+showNVA :: (Show s, Show sta, Show i, Show o, Show c) => NVA s sta i o c -> [Char]
+showNVA NVA{..} =
+  "initial: " <> intercalate ", " (show <$> toList initial) <> "\n"
+  <> "final: " <> intercalate ", " (show <$> toList final) <> "\n"
+  <> "trans:\n" <> intercalate "\n" (sort $ inners <> opens <> closes)
+  where
+    inners = NVA.toTriples innerTransitions
+      <&> \(p, l, q) -> "  " <> show p <> " --  " <> show l <> "     --> " <> show q
+    opens = NVA.toTriples openTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- <" <> show l <> ", +" <> show sta <> " --> " <> show q
+    closes = NVA.toTriples closeTransitions
+      <&> \(p, l, (sta, q)) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
+
 gNVA :: Gen (NVA State Sigma Sigma Sigma Sigma)
 gNVA = do
   initial <- G.subsequence [P ..] & G.filter (null >>> not) <&> S.fromList
@@ -99,6 +118,40 @@ gNVA = do
     & G.list (R.linear 0 10)
     <&> NVA.fromTriples
   pure NVA{..}
+
+showDVA :: (Show s, Show sta, Show i, Show o, Show c) => DVA s sta i o c -> [Char]
+showDVA DVA{..} =
+  "initial: " <> show initial <> "\n"
+  <> "final: " <> intercalate ", " (show <$> toList final) <> "\n"
+  <> "trans:\n" <> intercalate "\n" (sort $ inners <> opens <> closes)
+  where
+    toTriples = M.toList >=> traverse M.toList
+    inners = toTriples innerTransitions
+      <&> \(p, (l, q)) -> "  " <> show p <> " --  " <> show l <> "     --> " <> show q
+    opens = toTriples openTransitions
+      <&> \(p, (l, (sta, q))) -> "  " <> show p <> " -- <" <> show l <> ", +" <> show sta <> " --> " <> show q
+    closes = (M.toList >=> traverse (M.toList >=> traverse M.toList)) closeTransitions
+      <&> \(p, (l, (sta, q))) -> "  " <> show p <> " -- >" <> show l <> ", -" <> show sta <> " --> " <> show q
+
+gDVA :: Gen (DVA State Sigma Sigma Sigma Sigma)
+gDVA = do
+  initial <- G.element [P ..]
+  final <- G.subsequence [P ..] <&> S.fromList
+  innerTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> G.enumBounded
+    & G.list (R.linear 0 10)
+    <&> fromTriples
+  openTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> fromTriples
+  closeTransitions <- (,,) <$> G.enumBounded <*> G.enumBounded <*> ((,) <$> G.enumBounded <*> G.enumBounded)
+    & G.list (R.linear 0 10)
+    <&> fromQuads
+  pure DVA{..}
+  where
+    fromTriples = fmap (\(a, b, c) -> M.singleton a $ M.singleton b c)
+      >>> foldl' (M.unionWith (<>)) mempty
+    fromQuads = fmap (\(a, b, (c, d)) -> M.singleton a $ M.singleton b $ M.singleton c d)
+      >>> foldl' (M.unionWith (<>)) mempty
 
 -- TODO: better printing of automata and strings (and fix the intentional bug in EpsNVA.recognizes
 
@@ -132,5 +185,42 @@ prop_ReduceCorrect = withTests 10000 $ property $ do
   str <- forAllWith showStr gStr
   let r = NVA.recognizes nva str
       r' = NVA.recognizes nva' str
+  classify "any matches" $ r || r'
+  r === r'
+
+prop_shortestWordIsMatched :: Property
+prop_shortestWordIsMatched = withDiscards 10000 $ withTests 10000 $ property $ do
+  nva <- forAllWith showNVA gNVA
+  let nva' = NVA.reduce nva
+  annotate $ showNVA nva'
+  shouldDiscard <- discardSlow 1_000_000 $ case NVA.shortestWord nva' of
+    Nothing -> return True
+    Just str -> do
+      annotate $ showStr str
+      assert $ NVA.recognizes nva str
+      assert $ NVA.recognizes nva' str
+      return False
+  when shouldDiscard discard
+
+prop_differenceCorrect :: Property
+prop_differenceCorrect = withTests 10000 $ property $ do
+  dva1 <- forAllWith showDVA gDVA
+  dva2 <- forAllWith showDVA gDVA
+  str <- forAllWith showStr gStr
+  let diff = DVA.difference dva1 dva2
+  annotate $ showDVA diff
+  let r1 = DVA.recognizes dva1 str
+      r2 = DVA.recognizes dva2 str
+      r3 = DVA.recognizes diff str
+  (r1 && not r2) === r3
+
+prop_determinizeCorrect :: Property
+prop_determinizeCorrect = withTests 10000 $ property $ do
+  nva <- forAllWith showNVA gNVA
+  let dva = DVA.determinize nva
+  discardSlow 1_000_000 $ annotate $ showDVA dva
+  str <- forAllWith showStr gStr
+  let r = NVA.recognizes nva str
+      r' = DVA.recognizes dva str
   classify "any matches" $ r || r'
   r === r'

--- a/syncon-parser/test/Main.hs
+++ b/syncon-parser/test/Main.hs
@@ -8,8 +8,10 @@ import Pre
 import Hedgehog.Main (defaultMain)
 
 import qualified ParseTest
+import qualified AutomataTest
 
 main :: IO ()
 main = defaultMain
-  [ ParseTest.test
+  [ AutomataTest.test
+  , ParseTest.test
   ]

--- a/syncon-parser/test/Main.hs
+++ b/syncon-parser/test/Main.hs
@@ -4,74 +4,12 @@ module Main where
 
 import Prelude ()
 import Pre
-import Result (Result(..))
 
-import System.FilePath (takeFileName, isExtensionOf, (</>))
-import System.Directory (listDirectory, doesDirectoryExist, doesFileExist)
+import Hedgehog.Main (defaultMain)
 
-import Data.IORef (newIORef, readIORef, IORef, writeIORef)
-import qualified Data.HashMap.Strict as M
-import Data.List (partition)
-
-import P1Lexing.Types (Token)
-import qualified P1Lexing.Lexer as Lexer
-import P2LanguageDefinition.Types (TypeName(..))
-import qualified P2LanguageDefinition.Parser as LD
-import qualified P2LanguageDefinition.BasicChecker as LD
-import qualified P4Parsing.Parser as Parser
-import P4Parsing.Types (SingleLanguage(..))
+import qualified ParseTest
 
 main :: IO ()
-main = do
-  failRef <- newIORef False
-  langFiles <- getLanguages "languages"
-  mapM_ (langToTest failRef) langFiles
-  failed <- readIORef failRef
-  if failed
-    then exitFailure
-    else exitSuccess
-
-langToTest :: IORef Bool -> (FilePath, ([FilePath], ([FilePath], [FilePath]))) -> IO ()
-langToTest failRef (lang, (defFiles, (successFiles, failFiles))) = do
-  env <- mkEnv lang defFiles
-  mapM_ (mkTest env True) successFiles
-  mapM_ (mkTest env False) failFiles
-  where
-    mkTest (lexFile, precomputed) expected srcFile = do
-      toks <- doLexFile lexFile srcFile
-      let earleyResult = Parser.parseTokens precomputed toks & isData & (== expected)
-          showRes True  = "    "
-          showRes False = "FAIL"
-      putStrLn $ showRes earleyResult <> " parser/" <> lang <> "/" <> takeFileName srcFile <> "/earley-forest"
-      when (not earleyResult) $ writeIORef failRef True
-    doLexFile lexFile path = lexFile path >>= \case
-      Error _ -> die $ "Could not lex file " <> toS path
-      Data toks -> return toks
-    isData (Data (a, b)) = a `deepseq` b `deepseq` True
-    isData _ = False
-
-getLanguages :: FilePath -> IO [(FilePath, ([FilePath], ([FilePath], [FilePath])))]
-getLanguages languageDirectory = do
-  languages <- listDir languageDirectory >>= filterM doesDirectoryExist
-  forM languages $ \langDir -> do
-    files <- listDir langDir >>= filterM doesFileExist
-    let (defs, sources) = partition ("syncon" `isExtensionOf`) files
-        (fails, successes) = partition (takeFileName >>> ("fail_" `isPrefixOf`)) sources
-    return (takeFileName langDir, (defs, (successes, fails)))
-  where
-    listDir path = listDirectory path <&> fmap (path </>)
-
-mkEnv lang defFiles = mkDf >>= \df -> (,) <$> mkLexer df <*> mkEarleyParser df
-  where
-    mkDf = do
-      foldMapM LD.parseFile defFiles >>= \case
-        Error _ -> die $ "Could not parse a syncon-file for language " <> toS lang
-        Data tops -> case LD.mkDefinitionFile tops of
-          Error _ -> die $ "Could not create a complete definition for language " <> toS lang
-          Data df -> return df
-    mkLexer df = case Parser.dfToLanguageTokens df & Lexer.allOneLanguage SingleLanguage of
-      Error _ -> die $ "Could not generate a parser for lanugage " <> toS lang
-      Data lexFile -> return lexFile
-    mkEarleyParser df = case Parser.precomputeSingleLanguage @(Token SingleLanguage TypeName) df of
-      Error _ -> die $ "Could not generate earley parser for language " <> toS lang
-      Data precomputed -> return precomputed
+main = defaultMain
+  [ ParseTest.test
+  ]

--- a/syncon-parser/test/ParseTest.hs
+++ b/syncon-parser/test/ParseTest.hs
@@ -1,0 +1,73 @@
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module ParseTest (test) where
+
+import Prelude ()
+import Pre
+import Result (Result(..))
+
+import System.FilePath (takeFileName, isExtensionOf, (</>))
+import System.Directory (listDirectory, doesDirectoryExist, doesFileExist)
+
+import Data.IORef (newIORef, readIORef, IORef, writeIORef)
+import Data.List (partition)
+
+import P1Lexing.Types (Token)
+import qualified P1Lexing.Lexer as Lexer
+import P2LanguageDefinition.Types (TypeName(..), PrecedenceKind(PermissivePrecedence))
+import qualified P2LanguageDefinition.Parser as LD
+import qualified P2LanguageDefinition.BasicChecker as LD
+import qualified P4Parsing.Parser as Parser
+import P4Parsing.Types (SingleLanguage(..))
+
+test :: IO Bool
+test = do
+  failRef <- newIORef False
+  langFiles <- getLanguages "languages"
+  mapM_ (langToTest failRef) langFiles
+  not <$> readIORef failRef
+
+langToTest :: IORef Bool -> (FilePath, ([FilePath], ([FilePath], [FilePath]))) -> IO ()
+langToTest failRef (lang, (defFiles, (successFiles, failFiles))) = do
+  env <- mkEnv lang defFiles
+  mapM_ (mkTest env True) successFiles
+  mapM_ (mkTest env False) failFiles
+  where
+    mkTest (lexFile, precomputed) expected srcFile = do
+      toks <- doLexFile lexFile srcFile
+      let earleyResult = Parser.parseTokens precomputed toks & isData & (== expected)
+          showRes True  = "    "
+          showRes False = "FAIL"
+      putStrLn $ showRes earleyResult <> " parser/" <> lang <> "/" <> takeFileName srcFile <> "/earley-forest"
+      when (not earleyResult) $ writeIORef failRef True
+    doLexFile lexFile path = lexFile path >>= \case
+      Error _ -> die $ "Could not lex file " <> toS path
+      Data toks -> return toks
+    isData (Data (a, b)) = a `deepseq` b `deepseq` True
+    isData _ = False
+
+getLanguages :: FilePath -> IO [(FilePath, ([FilePath], ([FilePath], [FilePath])))]
+getLanguages languageDirectory = do
+  languages <- listDir languageDirectory >>= filterM doesDirectoryExist
+  forM languages $ \langDir -> do
+    files <- listDir langDir >>= filterM doesFileExist
+    let (defs, sources) = partition ("syncon" `isExtensionOf`) files
+        (fails, successes) = partition (takeFileName >>> ("fail_" `isPrefixOf`)) sources
+    return (takeFileName langDir, (defs, (successes, fails)))
+  where
+    listDir path = listDirectory path <&> fmap (path </>)
+
+mkEnv lang defFiles = mkDf >>= \df -> (,) <$> mkLexer df <*> mkEarleyParser df
+  where
+    mkDf = do
+      foldMapM LD.parseFile defFiles >>= \case
+        Error _ -> die $ "Could not parse a syncon-file for language " <> toS lang
+        Data tops -> case LD.mkDefinitionFile PermissivePrecedence tops of
+          Error _ -> die $ "Could not create a complete definition for language " <> toS lang
+          Data df -> return df
+    mkLexer df = case Parser.dfToLanguageTokens df & Lexer.allOneLanguage SingleLanguage of
+      Error _ -> die $ "Could not generate a parser for lanugage " <> toS lang
+      Data lexFile -> return lexFile
+    mkEarleyParser df = case Parser.precomputeSingleLanguage @(Token SingleLanguage TypeName) df of
+      Error _ -> die $ "Could not generate earley parser for language " <> toS lang
+      Data precomputed -> return precomputed


### PR DESCRIPTION
This PR reimplements the complete dynamic ambiguity analysis and adds options for running it instead of the default fast one (and running both and picking the fastest). This makes the `pbt` command a little bit more trustworthy.

Since the dynamic analysis has poor time complexity it's not always viable to run it to completion. This is especially apparent when running `pbt` since it easily creates really large ambiguities, larger than the ones that normally appear when writing a normal program. This means that we put a timeout on the analysis, then discard tests that break this timeout. However, the fast (default) analysis is not complete, in the sense that it might not terminate on an unresolvable ambiguity. This means that an unresolvable ambiguity could slip by as a discarded test case, since we can't distinguish the two.

This PR thus readds the complete algorithm, which commonly is slower, but is guaranteed to terminate.