### PR TITLE
Add a sanity check for suggested resolutions

### DIFF
--- a/syncon-parser/examples/reparse-failure.syncon
+++ b/syncon-parser/examples/reparse-failure.syncon
@@ -1,0 +1,3 @@
+syncon a: Top = a:"a" "b"?
+syncon b: Top = a:"a" "b"? ("c" "d")?
+syncon c: Top = a:"a" "b" "c" "d"

--- a/syncon-parser/examples/reparse-failure.syncon
+++ b/syncon-parser/examples/reparse-failure.syncon
@@ -1,3 +1,3 @@
-syncon a: Top = a:"a" "b"?
-syncon b: Top = a:"a" "b"? ("c" "d")?
-syncon c: Top = a:"a" "b" "c" "d"
+syncon synA: Top = a:"a" "b"?
+syncon synB: Top = a:"a" "b"? ("c" "d")?
+syncon synC: Top = a:"a" "b" "c" "d"

--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -54,6 +54,7 @@ import qualified P5DynamicAmbiguity.Types as DynAmb
 import qualified P5DynamicAmbiguity.TreeLanguage as DynAmb
 import qualified P5DynamicAmbiguity.Isolation as DynAmb
 import qualified P5DynamicAmbiguity.Analysis as DynAmb
+import qualified P5DynamicAmbiguity.PatchTokenStream as DynAmb
 
 import qualified P6Output.JsonV1 as Output
 

--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -174,6 +174,9 @@ parseAction = do
   continueAfterError <- Opt.switch
     $ Opt.long "continue-after-error"
     <> Opt.help "Don't abort after the first source file that gives errors."
+  reparse <- Opt.switch
+    $ Opt.long "reparse-resolution"
+    <> Opt.help "Sanity check, reparses each suggested ambiguity resolution to see if it does indeed solve the ambiguity. May give false positives on nested ambiguities."
 
   pure $ \(preParse, pl) files -> do
     sources <- files <&> toS & S.fromList & S.toMap
@@ -187,22 +190,37 @@ parseAction = do
                   then DynAmb.dummyIsolate >>> first Seq.singleton
                   else DynAmb.isolate
         fastAnalyze = DynAmb.analyze dynAmbTimeout pl DynAmb.convertToken
-        completeAnalyze = \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
+        completeAnalyze = \a b c -> DynAmb.completeAnalyze pl DynAmb.convertToken a b c >>> return
         analyze = case fromMaybe FastDyn dynAmbKind of
-          FastDyn -> DynAmb.analyze dynAmbTimeout pl DynAmb.convertToken
-          CompleteDyn -> \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
-          RaceDyn -> \a b c -> race (fastAnalyze a b c) (completeAnalyze a b c) <&> either identity identity
+          FastDyn -> fastAnalyze
+          CompleteDyn -> completeAnalyze
+          RaceDyn -> \a b c d -> race (fastAnalyze a b c d) (completeAnalyze a b c d) <&> either identity identity
     srcNodes <- flip M.traverseWithKey sources $ \path _ -> do
       putStrLn $ "Parsing \"" <> path <> "\""
       handle (\(SourceFileException t) -> modifyIORef' failureFiles (+1) >> sourceFailureHandler t) $ do
         mNode <- timeout sourceTimeout $ do
-          forest@(nodeMap, _) <- Parser.parseFile preParse (toS path) >>= dataOrError' sources ()
+          (nodeMap, tops, Seq.fromList -> tokens) <- Parser.parseFile' preParse (toS path) >>= dataOrError' sources ()
+          let forest = (nodeMap, tops)
           forM_ dot $ \outPath -> do
             let fullPath = outPath </> toS path <.> "dot"
             putStrLn @Text $"Writing to \"" <> toS fullPath <> "\""
             createDirectoryIfMissing True $ takeDirectory fullPath
             Parser.forestToDot (Parser.n_nameF >>> coerce) forest
               & writeFile fullPath
+          let getBounds = DynAmb.getElidableBoundsEx nodeMap
+          let checkReparse elidable replacement
+                | not reparse = True
+                | otherwise =
+                  let bounds = case toList elidable of
+                        e : _ -> DynAmb.getNodeOrElidableBoundsEx nodeMap e
+                        [] -> compErr "Main.parseAction.checkReparse" "Empty elidable"
+                  in DynAmb.patch Parser.SingleLanguage getBounds bounds (Seq.fromList replacement) tokens
+                     & Parser.parseTokens preParse
+                     & first (const Seq.empty)
+                     >>= isolate
+                     & \case
+                       Data _ -> True
+                       Error _ -> False
           isolate forest & \case
             Data node -> modifyIORef' successfulFiles (+1) >> return node
             Error ambs ->
@@ -213,11 +231,13 @@ parseAction = do
                     , DynAmb.showTok = Forest.unlex
                     , DynAmb.tokRange = range
                     }
-              in ambs
-                 & mapM (foldMap S.singleton >>> analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
-                 <&> fmap (formatError opts)
-                 <&> formatErrors sources
-                 >>= die'
+              in do
+                errs <- forM ambs $ foldMap S.singleton >>> \amb ->
+                  analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap) (checkReparse amb) amb
+                  <&> formatError opts
+                errs
+                 & formatErrors sources
+                 & die'
         maybe (die' "        timeout when parsing file") return mNode
 
     numSuccesses <- readIORef successfulFiles
@@ -367,6 +387,9 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
       noIsolation <- Opt.switch
         $ Opt.long "no-isolation"
         <> Opt.help "Do not isolate ambiguities, instead treat the entire file as ambiguous."
+      reparse <- Opt.switch
+        $ Opt.long "reparse-resolution"
+        <> Opt.help "Sanity check, reparses each suggested ambiguity resolution to see if it does indeed solve the ambiguity. May give false positives on nested ambiguities."
       files <- some $ Opt.argument Opt.str $
         Opt.metavar "FILES..."
         <> Opt.help "The '.syncon' files that define the language to be tested."
@@ -384,11 +407,11 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
               UnresolvableAmbiguity -> RaceDyn
               Ambiguity -> FastDyn
             fastAnalyze = DynAmb.analyze (-1) pl DynAmb.convertToken
-            completeAnalyze = \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
+            completeAnalyze = \a b c -> DynAmb.completeAnalyze pl DynAmb.convertToken a b c >>> return
             analyze = case fromMaybe defDynAmbKind dynAmbKind of
-              FastDyn -> DynAmb.analyze (-1) pl DynAmb.convertToken
-              CompleteDyn -> \a b -> DynAmb.completeAnalyze pl DynAmb.convertToken a b >>> return
-              RaceDyn -> \a b c -> race (fastAnalyze a b c) (completeAnalyze a b c) <&> either identity identity
+              FastDyn -> fastAnalyze
+              CompleteDyn -> completeAnalyze
+              RaceDyn -> \a b c d -> race (fastAnalyze a b c d) (completeAnalyze a b c d) <&> either identity identity
         let gen = Parser.programGenerator df
             prop = Hedgehog.withDiscards (fromInteger numDiscards) $ Hedgehog.withTests (fromInteger numRuns) $ Hedgehog.property $ do
               (size, syncons, types, Lexer.makeFakeFile -> (sources, program)) <- Hedgehog.forAllWith ((\(_, _, _, x) -> x) >>> toList >>> fmap Forest.unlex >>> Text.intercalate " " >>> toS) gen
@@ -406,9 +429,24 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                   Data forest@(nodeMap, _) -> case isolate forest of
                     Data _ -> when showAmbDistr (Hedgehog.label "unambiguous") >> Hedgehog.success
                     Error ambs -> do
+                      let analyze' = analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap)
+                      let getBounds = DynAmb.getElidableBoundsEx nodeMap
+                      let checkReparse elidable replacement
+                            | not reparse = True
+                            | otherwise =
+                              let bounds = case toList elidable of
+                                    e : _ -> DynAmb.getNodeOrElidableBoundsEx nodeMap e
+                                    [] -> compErr "Main.parseAction.checkReparse" "Empty elidable"
+                              in DynAmb.patch Parser.SingleLanguage getBounds bounds (Seq.fromList replacement) program
+                                 & Parser.parseTokens preParse
+                                 & first (const Seq.empty)
+                                 >>= isolate
+                                 & \case
+                                   Data _ -> True
+                                   Error _ -> False
                       when showAmbDistr $ Hedgehog.label "ambiguous"
                       errs <- ambs
-                        & mapM (foldMap S.singleton >>> analyze (DynAmb.getElidable pl nodeMap) (DynAmb.showElidable nodeMap))
+                        & mapM (\amb -> foldMap S.singleton amb & analyze' (checkReparse amb))
                         <&> Seq.filter (hasAmbStyle target)
                         & lift
                       if Seq.null errs

--- a/syncon-parser/src/P4Parsing/Parser.hs
+++ b/syncon-parser/src/P4Parsing/Parser.hs
@@ -1,6 +1,17 @@
 {-# LANGUAGE RecordWildCards, ViewPatterns, UndecidableInstances #-}
 
-module P4Parsing.Parser (Error(..), precomputeSingleLanguage, dfToLanguageTokens, parseTokens, parseFile, forestToDot, precomputeToSerialisable, serialisableToPrecompute, Precomputed) where
+module P4Parsing.Parser
+( Error(..)
+, precomputeSingleLanguage
+, dfToLanguageTokens
+, parseTokens
+, parseFile
+, parseFile'
+, forestToDot
+, precomputeToSerialisable
+, serialisableToPrecompute
+, Precomputed
+) where
 
 import Pre hiding (from, some, many, optional)
 import Result (Result(..))
@@ -72,6 +83,13 @@ precomputeSingleLanguage df = do
   grammar <- generateGrammar df
   let forest = mkGrammar (unquant grammar) & mkNNFGrammar & precompute
   return Precomputed{..}
+
+parseFile' :: Precomputed l
+           -> FilePath
+           -> IO (Res l (Token l TypeName) (HashMap Node (NodeF (Token l TypeName) (HashSet Node)), HashSet Node, [Token l TypeName]))
+parseFile' pc@Precomputed{lexFile} path = do
+  resTokens <- lexFile path
+  return $ resTokens >>= \toks -> parseTokens pc toks <&> \(nodeMap, tops) -> (nodeMap, tops, toks)
 
 parseFile :: Precomputed l
           -> FilePath

--- a/syncon-parser/src/P5DynamicAmbiguity/PatchTokenStream.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/PatchTokenStream.hs
@@ -1,4 +1,4 @@
-module P5DynamicAmbiguity.PatchTokenStream where
+module P5DynamicAmbiguity.PatchTokenStream (patch) where
 
 import Pre
 

--- a/syncon-parser/src/P5DynamicAmbiguity/PatchTokenStream.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/PatchTokenStream.hs
@@ -1,0 +1,49 @@
+module P5DynamicAmbiguity.PatchTokenStream where
+
+import Pre
+
+import Data.Sequence (pattern (:<|), pattern (:|>), pattern Empty)
+import qualified Data.Sequence as Seq
+
+import qualified P1Lexing.Types as P1
+import qualified P2LanguageDefinition.Types as P2
+import qualified P5DynamicAmbiguity.Types as P5
+
+type Token5 elidable = P5.Token elidable
+type Token1 l = P1.Token l P2.TypeName
+
+patch :: Eq l => l -> (elidable -> (Token1 l, Token1 l))
+      -> (Token1 l, Token1 l) -> Seq (Token5 elidable) -> Seq (Token1 l) -> Seq (Token1 l)
+patch l getBounds bounds toSpliceIn original = prefix <> splice l getBounds toSpliceIn middle <> postfix
+  where
+    (prefix, middle, postfix) = triSplit bounds original
+
+
+splice :: Eq l => l -> (elidable -> (Token1 l, Token1 l)) -> Seq (Token5 elidable) -> Seq (Token1 l) -> Seq (Token1 l)
+splice l getBounds = recur
+  where
+    unexpectedElided = compErr "P5DynamicAmbiguity.PatchTokenStream.splice" "unexpected elided token"
+
+    recur spliceSeq original = Seq.spanl (not . isElided) spliceSeq
+      & first (P5.makeFakeToken l unexpectedElided <$>)
+      & \case
+      (nonElided, Empty) -> nonElided
+      (nonElided, P5.ElidedTok e :<| spliceSeq') ->
+        let (_, elided, original') = triSplit (getBounds e) original
+        in nonElided <> elided <> recur spliceSeq' original'
+      (_, _ :<| _) -> compErr "P5DynamicAmbiguity.PatchTokenStream.splice.recur" "expected an elided token"
+
+triSplit :: Eq a => (a, a) -> Seq a -> (Seq a, Seq a, Seq a)
+triSplit (firstA, lastA) = Seq.spanl (/= firstA)
+  >>> fmap (spanInclEx (/= lastA))
+  >>> \(prefix, (middle, postfix)) -> (prefix, middle, postfix)
+  where
+    spanInclEx :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
+    spanInclEx f s = case Seq.spanl f s of
+      (prefix, match :<| postfix) -> (prefix :|> match, postfix)
+      _ -> compErr "P5DynamicAmbiguity.PatchTokenStream.triSplit.spanInclEx" "no matching element"
+
+
+isElided :: Token5 elidable -> Bool
+isElided P5.ElidedTok{} = True
+isElided _ = False

--- a/syncon-parser/src/P5DynamicAmbiguity/Types.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Types.hs
@@ -42,6 +42,12 @@ convertToken :: P1.Token l P2.TypeName -> Token elidable
 convertToken (P1.LitTok _ _ t) = LitTok t
 convertToken (P1.OtherTok _ _ tyn t) = OtherTokInstance tyn t
 
+makeFakeToken :: l -> (elidable -> P1.Token l P2.TypeName) -> Token elidable -> P1.Token l P2.TypeName
+makeFakeToken l _ (LitTok t) = P1.LitTok mempty l t
+makeFakeToken l _ (OtherTokInstance tyn t) = P1.OtherTok mempty l tyn t
+makeFakeToken l _ (OtherTok tyn) = P1.OtherTok mempty l tyn ("<" <> show tyn <> ">")
+makeFakeToken _ fromElide (ElidedTok e) = fromElide e
+
 instance Eq elidable => Eq (Token elidable) where
   (==) = (==) `on` eitherRepr
 instance Hashable elidable => Hashable (Token elidable) where

--- a/syncon-parser/syncon.cabal
+++ b/syncon-parser/syncon.cabal
@@ -121,6 +121,7 @@ library
                  , P5DynamicAmbiguity.TreeLanguage
                  , P5DynamicAmbiguity.Analysis
                  , P5DynamicAmbiguity.Isolation
+                 , P5DynamicAmbiguity.PatchTokenStream
                  , P6Output.JsonV1
   default-language: Haskell2010
   default-extensions: NoImplicitPrelude


### PR DESCRIPTION
The current dynamic analysis is not guaranteed to present unambiguous resolutions of an ambiguity, only resolutions that disambiguate between the currently visible alternatives.

For example, this language will produce a faulty resolution when parsing `a b c d`:

```
syncon synA: Top = a:"a" "b"?
syncon synB: Top = a:"a" "b"? ("c" "d")?
syncon synC: Top = a:"a" "b" "c" "d"
```

The reparsing check added by this PR applies the resolution to the token stream, then reparses it and checks if it's ambiguous in which case it produces a warning:

```
Unresolvable ambiguity error with 2 alternatives.
Resolutions marked '<(!)>' do not fully resolve
all ambiguities in this program.

Resolvable alternatives:
  <(!)> a
  synB
   - a                    <generated>:1:1-2


Unresolvable alternatives:
  synC
   - a                    <generated>:1:1-2

 <generated>#1:1:
   1: a b c d
```