### PR TITLE
Add more performance stats, and logging to CSV

### DIFF
--- a/syncon-parser/exe/HedgehogExtra.hs
+++ b/syncon-parser/exe/HedgehogExtra.hs
@@ -1,0 +1,17 @@
+module HedgehogExtra (checkInformative, Report(..), Result(..), wasSuccess) where
+
+import Pre
+
+import Hedgehog (Property)
+import Hedgehog.Internal.Runner (checkNamed)
+import Hedgehog.Internal.Region (displayRegion)
+import Hedgehog.Internal.Report (Report(..), Result(..))
+
+checkInformative :: MonadIO m => Property -> m (Report Result)
+checkInformative prop =
+  liftIO . displayRegion $ \region ->
+    checkNamed region Nothing Nothing prop
+
+wasSuccess :: Report Result -> Bool
+wasSuccess Report{reportStatus = OK} = True
+wasSuccess _ = False

--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -529,7 +529,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                         Hedgehog.failure
         putStrLn @Text "Running pbt test"
         (time, result) <- Timer.time $ Hedgehog.checkInformative prop
-        putStrLn @Text $ "Pbt test complete, took " <> show time <> "s"
+        putStrLn @Text $ "Pbt test complete, took " <> toS (Timer.formatSeconds time)
         let key = Text.intercalate ", " $ toS <$> files
         forM_ dynLogFile $ \dynLogFilePath -> do
           readIORef dynLog

--- a/syncon-parser/src/P5DynamicAmbiguity/Analysis.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Analysis.hs
@@ -1,4 +1,13 @@
-module P5DynamicAmbiguity.Analysis (analyze, completeAnalyze, Error, ErrorOptions(..), ambiguityStyle, AmbiguityStyle(..), didTimeout) where
+module P5DynamicAmbiguity.Analysis
+( analyze
+, completeAnalyze
+, Error
+, ErrorOptions(..)
+, ambiguityStyle
+, AmbiguityStyle(..)
+, didTimeout
+, countReparseFailures
+) where
 
 import Pre hiding (reduce)
 
@@ -31,6 +40,12 @@ ambiguityStyle (Ambiguity _ _ [] []) = panic $ "Unexpectedly empty ambiguity err
 didTimeout :: Error elidable tok -> Bool
 didTimeout (Ambiguity _ DidTimeout _ _) = True
 didTimeout _ = False
+
+countReparseFailures :: Error elidable tok -> Int
+countReparseFailures (Ambiguity _ _ resolvable _) =
+  resolvable
+  & filter (snd >>> snd >>> not)
+  & length
 
 instance FormatError (Error elidable tok) where
   type ErrorOpts (Error elidable tok) = ErrorOptions elidable tok

--- a/syncon-parser/src/P5DynamicAmbiguity/Types.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module P5DynamicAmbiguity.Types where
 
 import Pre
@@ -13,6 +15,12 @@ data NodeOrElide elidable t
   = Node !(P4.NodeF t (NodeOrElide elidable t))
   | Elide !elidable
   deriving (Show, Generic, Eq)
+
+countNodesInNodeOrElide :: NodeOrElide elidable t -> Int
+countNodesInNodeOrElide = recur >>> getSum
+  where
+    recur (Node n) = Sum 1 <> foldMap recur n
+    recur (Elide _) = Sum 1
 
 data Token elidable
   = LitTok !Text

--- a/syncon-parser/stack.yaml
+++ b/syncon-parser/stack.yaml
@@ -41,6 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - pretty-terminal-0.1.0.0
+- microtimer-0.0.1.2@sha256:daf649a763408f8dc118e0ac2cedd847b426252377a958e0d3aacc8cb4db2c34,1092
 
 
 # Override default flag values for local packages and extra-deps

--- a/syncon-parser/stack.yaml.lock
+++ b/syncon-parser/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       sha256: fecec01e618890c284e57cb873b8f9531f479562b7cf08497aef097da3ef90ec
   original:
     hackage: pretty-terminal-0.1.0.0
+- completed:
+    hackage: microtimer-0.0.1.2@sha256:daf649a763408f8dc118e0ac2cedd847b426252377a958e0d3aacc8cb4db2c34,1092
+    pantry-tree:
+      size: 431
+      sha256: 2739f80662e6d85ff22e7aab5a2623fd04e982d3bd9a7ea6175cecaac6d7e376
+  original:
+    hackage: microtimer-0.0.1.2@sha256:daf649a763408f8dc118e0ac2cedd847b426252377a958e0d3aacc8cb4db2c34,1092
 snapshots:
 - completed:
     size: 523443

--- a/syncon-parser/syncon.cabal
+++ b/syncon-parser/syncon.cabal
@@ -12,6 +12,7 @@ executable syncon-parser
   default-language: Haskell2010
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -funbox-strict-fields
   other-modules: RandomCompose
+               , HedgehogExtra
   build-depends: base
                , random
                , array
@@ -31,6 +32,7 @@ executable syncon-parser
                , earley-forest
                , hedgehog
                , lifted-async
+               , microtimer
   default-extensions: NoImplicitPrelude
                     , EmptyCase
                     , FlexibleContexts


### PR DESCRIPTION
Previously the tool gave a decent amount of information about PBT runs, but only to stdout, and not in an easily machine-readable fashion. This PR adds two flags `--dyn-log-file <file.csv>` and `--summary-log-file <file.csv>` that output more data in CSV format. The former has one line per run of the dynamic analysis, while the latter has one line per run of `syncon-parser pbt` (both append to the given file, i.e., multiple runs can write to the same file).

The data logged by `--dyn-log-file` is the following:
- `.syncon` files that define the language
- Time taken for each dynamic analysis
- Number of reparse failures
- Size of ambiguity (no. alternatives, no. nodes in each alternative and their sum, no. tokens in the ambiguity)

The data logged by `--summary-log-file` is the following:
- `.syncon` files that define the language
- Time taken for the complete PBT run (i.e., not including parsing the definition files and that stuff, but including generating test programs and parsing them and the like)
- Number of tests total
- Number of tests discarded (due to timeout)
- Which ambiguity kind was targeted (unresolvable ambiguity or any ambiguity)
- Whether it found the targeted kind of ambiguity
