### PR TITLE
Group by ambiguity root

### DIFF
--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -216,6 +216,7 @@ parseAction = do
                 , dCheckReparses = checkReparse
                 , dKind = dynAmbKind
                 , dGroupByTop = groupByTop
+                , dGetElidedTokRange = DynAmb.getElidableBoundsEx nodeMap
                 }
           let checkReparse elidable replacement
                 | not reparse = True
@@ -493,6 +494,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                             , dCheckReparses = checkReparse
                             , dKind = dynAmbKind
                             , dGroupByTop = groupByTop
+                            , dGetElidedTokRange = DynAmb.getElidableBoundsEx nodeMap
                             }
                       let analyze' checkReparse amb = do
                             forM_ dynLogFile $ \_ -> atomicModifyIORef' dynLog (addDynMeta getBounds program amb)

--- a/syncon-parser/src/Data/Automaton/EpsilonNVA.hs
+++ b/syncon-parser/src/Data/Automaton/EpsilonNVA.hs
@@ -33,6 +33,7 @@ data TaggedTerminal i o c
   | Close c
   deriving (Eq, Generic, Show)
 instance (Hashable i, Hashable o, Hashable c) => Hashable (TaggedTerminal i o c)
+instance (NFData i, NFData o, NFData c) => NFData (TaggedTerminal i o c)
 
 recognizes :: forall s sta i o c. (Eq s, Hashable s, Eq sta, Hashable sta, Eq i, Hashable i, Eq o, Hashable o, Eq c, Hashable c)
            => EpsNVA s sta i o c -> [TaggedTerminal i o c] -> Bool

--- a/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
@@ -1,4 +1,12 @@
-module P5DynamicAmbiguity.Isolation (isolate, dummyIsolate, getElidable, showElidable, getElidableBoundsEx, getNodeOrElidableBoundsEx, Elidable) where
+module P5DynamicAmbiguity.Isolation
+( isolate
+, dummyIsolate
+, getElidable
+, showElidable
+, getElidableBoundsEx
+, getNodeOrElidableBoundsEx
+, Elidable
+) where
 
 import Pre hiding (reduce, State, state, orElse)
 import Result (Result(..))

--- a/syncon-parser/src/P5DynamicAmbiguity/Types.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Types.hs
@@ -15,6 +15,7 @@ data NodeOrElide elidable t
   = Node !(P4.NodeF t (NodeOrElide elidable t))
   | Elide !elidable
   deriving (Show, Generic, Eq)
+instance (NFData elidable, NFData t) => NFData (NodeOrElide elidable t)
 
 countNodesInNodeOrElide :: NodeOrElide elidable t -> Int
 countNodesInNodeOrElide = recur >>> getSum
@@ -29,6 +30,7 @@ data Token elidable
   | ElidedTok !elidable
   deriving (Show, Generic)
 instance Serialise elidable => Serialise (Token elidable)
+instance NFData elidable => NFData (Token elidable)
 
 eitherRepr :: Token elidable -> Either Text (Either P2.TypeName elidable)
 eitherRepr (LitTok t) = Left t


### PR DESCRIPTION
Thus far the dynamic analysis has worked hard to fully resolve an ambiguity. This means that every possible AST should have an unambiguous resolution. For example, given that `+` has no associativity or precedence, we could get the following error:

```
Ambiguity error with 14 alternatives.

  ( ( 1 + 2 ) + 3 ) + ( 4 + 5 )
  ( ( 1 + 2 ) + ( 3 + 4 ) ) + 5
  1 + ( 2 + ( ( 3 + 4 ) + 5 ) )
  ( ( 1 + ( 2 + 3 ) ) + 4 ) + 5
  ( 1 + 2 ) + ( ( 3 + 4 ) + 5 )
  ( ( ( 1 + 2 ) + 3 ) + 4 ) + 5
  ( 1 + ( 2 + ( 3 + 4 ) ) ) + 5
  ( 1 + ( ( 2 + 3 ) + 4 ) ) + 5
  1 + ( 2 + ( 3 + ( 4 + 5 ) ) )
  1 + ( ( 2 + ( 3 + 4 ) ) + 5 )
  1 + ( ( ( 2 + 3 ) + 4 ) + 5 )
  ( 1 + ( 2 + 3 ) ) + ( 4 + 5 )
  1 + ( ( 2 + 3 ) + ( 4 + 5 ) )
  ( 1 + 2 ) + ( 3 + ( 4 + 5 ) )

 examples/ambig.test#13:7:
  13: print 1 + 2 + 3 + 4 + 5
```

This shows every possible grouping of summing five terms and is quite verbose. It also scales poorly, adding another term gives 42 alternatives, while one fewer has just 5 alternatives.

This PR makes the dynamic analysis capable of looking for a partial resolution, one that only resolves the top node of the AST:

```
Ambiguity error with 4 alternatives.

  ( 1 + 2 + 3 + 4 ) + 5
  1 + ( 2 + 3 + 4 + 5 )
  ( 1 + 2 ) + ( 3 + 4 + 5 )
  ( 1 + 2 + 3 ) + ( 4 + 5 )

 examples/ambig.test#13:7:
  13: print 1 + 2 + 3 + 4 + 5
```

These resolutions naturally do not fully resolve the ambiguity, but they do produce smaller ambiguities, letting a user deal with one part of the problem at a time.