### PR TITLE
Allow a language to explicitly state known ambiguities

### DIFF
--- a/syncon-mode.el
+++ b/syncon-mode.el
@@ -22,6 +22,7 @@
        "syncon"
        "token"
        "type"
+       "ambiguity"
       ))
 
 (setq syncon-operators

--- a/syncon-parser/examples/bootstrap.syncon
+++ b/syncon-parser/examples/bootstrap.syncon
@@ -6,6 +6,7 @@
 token Name = "[[:lower:]][[:word:]]*"
 token TypeName = "[[:upper:]][[:word:]]*"
 token String = "\"(\\\\.|[^\"\\\\])*\""
+token Integer = "[[:digit:]]+"
 
 comment "//[^\\n]*(\\n|$)"
 
@@ -29,6 +30,13 @@ syncon blockCommentDef: Decl = "comment" openRegex:String closeRegex:String
 
 syncon groupingDef: Decl =
   "grouping" (oStr:String | oTy:TypeName) ty:TypeName (cStr:String | cTy:TypeName)
+
+// === Acceptable Ambiguity Definitions ===
+
+syncon ambiguityDef: Decl =
+  "ambiguity" "{"
+    line:((sizes:Integer+ ":")? name:Name+ ";")+
+  "}"
 
 // === Syncon Definitions (including operators) ===
 

--- a/syncon-parser/examples/bootstrap_regex.syncon
+++ b/syncon-parser/examples/bootstrap_regex.syncon
@@ -60,6 +60,13 @@ syncon blockCommentDef: Decl = "comment" openRegex:Regex closeRegex:Regex
 syncon groupingDef: Decl =
   "grouping" (oStr:String | oTy:TypeName) ty:TypeName (cStr:String | cTy:TypeName)
 
+// === Acceptable Ambiguity Definitions ===
+
+syncon ambiguityDef: Decl =
+  "ambiguity" "{"
+    line:((sizes:Integer+ ":")? name:Name+ ";")+
+  "}"
+
 // === Syncon Definitions (including operators) ===
 
 syncon synconDef: Decl =

--- a/syncon-parser/src/P2LanguageDefinition/Parser.hs
+++ b/syncon-parser/src/P2LanguageDefinition/Parser.hs
@@ -98,8 +98,9 @@ tops = mdo
   syn <- fmap (SynconTop >>> pure) <$> synconDef
   pre <- fmap (SynconTop >>> pure) <$> prefixDef
   post <- fmap (SynconTop >>> pure) <$> postfixDef
+  aa <- fmap (AcceptedAmbiguityTop >>> pure) <$> ambiguityDef
   inf <- fmap (\(s, f') -> foldr (:) [SynconTop s] $ ForbidTop <$> f') <$> infixDef
-  return . fmap concat . many $ st <|> tt <|> c <|> syn <|> pre <|> post <|> inf <|> f <|> pl <|> g
+  return . fmap concat . many $ st <|> tt <|> c <|> syn <|> pre <|> post <|> inf <|> f <|> pl <|> g <|> aa
 
 -- | Parse a syntax type declaration
 syntaxTypeDef :: Grammar r (Prod r SyntaxType)
@@ -159,6 +160,17 @@ groupingDef = rule . (<?> "grouping disambiguation") $ do
     , g_close = close
     , g_syntaxType = tyn
     , g_range = range start <> fst close
+    }
+
+ambiguityDef :: Grammar r (Prod r AcceptedAmbiguity)
+ambiguityDef = rule . (<?> "acceptable ambiguity declaration") $ do
+  start <- lit "ambiguity" <* lit "{"
+  aList <- Seq.fromList <$> some name <* lit ";"
+    & some <&> Seq.fromList
+  end <- lit "}"
+  pure $ AcceptedAmbiguity
+    { aa_range = range start <> range end
+    , aa_accepted = aList
     }
 
 -- |

--- a/syncon-parser/src/P2LanguageDefinition/Parser.hs
+++ b/syncon-parser/src/P2LanguageDefinition/Parser.hs
@@ -42,7 +42,7 @@ instance FormatError Error where
 
 data SynconDefinitionLanguage = SynconDefinitionLanguage deriving (Eq, Generic, Show)
 
-data TokenKind = NameTok | TypeNameTok | StringTok deriving (Eq, Generic, Show)
+data TokenKind = NameTok | TypeNameTok | StringTok | IntTok deriving (Eq, Generic, Show)
 
 instance Hashable SynconDefinitionLanguage
 instance Hashable TokenKind
@@ -79,7 +79,8 @@ synconTokens = Lexer.LanguageTokens
   -- Regex tokens
   [ (NameTok, (Nowhere, "[[:lower:]][[:word:]]*"))
   , (TypeNameTok, (Nowhere, "[[:upper:]][[:word:]]*"))
-  , (StringTok, (Nowhere, "\"(\\\\.|[^\"\\\\])*\"")) ]
+  , (StringTok, (Nowhere, "\"(\\\\.|[^\"\\\\])*\""))
+  , (IntTok, (Nowhere, "[[:digit:]]+"))]
   -- Comment regex
   [((Nowhere, "//[^\\n]*(\\n|$)"), (Nowhere, "^"))]
 
@@ -165,7 +166,7 @@ groupingDef = rule . (<?> "grouping disambiguation") $ do
 ambiguityDef :: Grammar r (Prod r AcceptedAmbiguity)
 ambiguityDef = rule . (<?> "acceptable ambiguity declaration") $ do
   start <- lit "ambiguity" <* lit "{"
-  aList <- Seq.fromList <$> some name <* lit ";"
+  aList <- (,) <$> (optional $ Seq.fromList <$> some int <* lit ":") <*> (Seq.fromList <$> some name <* lit ";")
     & some <&> Seq.fromList
   end <- lit "}"
   pure $ AcceptedAmbiguity
@@ -332,3 +333,9 @@ lit :: Text -> Prod r Tok
 lit t = (<?> show t) . satisfy $ \case
   LitTok _ _ t' | t == t' -> True
   _ -> False
+
+-- | Parse an integer
+int :: Prod r (Range, Int)
+int = (<?> "integer") . terminal $ \case
+  OtherTok r _ IntTok str -> readMaybe (toS str) <&> (r,)
+  _ -> Nothing

--- a/syncon-parser/src/P2LanguageDefinition/Parser.hs
+++ b/syncon-parser/src/P2LanguageDefinition/Parser.hs
@@ -75,7 +75,7 @@ synconTokens = Lexer.LanguageTokens
   -- Literal tokens
   [ "token", "=", "syncon", ":", "{", ";", "}", "prefix", "postfix", "infix"
   , "(", ")", "*", "+", "?", ".", "comment", "left", "right", "precedence", "except"
-  , "type", "builtin", "forbid", "|", "rec", "grouping", "!" ]
+  , "type", "builtin", "forbid", "|", "rec", "grouping", "!", "ambiguity" ]
   -- Regex tokens
   [ (NameTok, (Nowhere, "[[:lower:]][[:word:]]*"))
   , (TypeNameTok, (Nowhere, "[[:upper:]][[:word:]]*"))

--- a/syncon-parser/src/P2LanguageDefinition/Types.hs
+++ b/syncon-parser/src/P2LanguageDefinition/Types.hs
@@ -154,7 +154,7 @@ instance Hashable OpOrNot
 -- | A list of acceptable ambiguities
 data AcceptedAmbiguity = AcceptedAmbiguity
   { aa_range :: !Range
-  , aa_accepted :: !(Seq (Seq (Range, Name)))
+  , aa_accepted :: !(Seq (Maybe (Seq (Range, Int)), Seq (Range, Name)))
   } deriving (Show, Data)
 
 -- | A (sparse) matrix of precedences. Should only ever contain references to syncons

--- a/syncon-parser/src/P2LanguageDefinition/Types.hs
+++ b/syncon-parser/src/P2LanguageDefinition/Types.hs
@@ -36,6 +36,7 @@ data DefinitionFile = DefinitionFile
   , bracketKindInfo :: !BracketKindInfo
   , groupings :: !(HashMap TypeName (Seq (Either Text TypeName, Either Text TypeName)))
   , precedenceKind :: !PrecedenceKind
+  , acceptedAmbiguities :: !(HashSet (HashSet Name))
   }
 
 newtype BracketKindInfo = BracketKindInfo (HashMap (Either Text TypeName) BracketKind) deriving (Serialise)
@@ -56,6 +57,7 @@ data Top
   | ForbidTop Forbid
   | PrecedenceTop PrecedenceList
   | GroupingTop Grouping
+  | AcceptedAmbiguityTop AcceptedAmbiguity
   deriving (Show, Data, Typeable)
 
 -- |
@@ -148,6 +150,12 @@ data PrecedenceList = PrecedenceList !Range !(Seq (Seq (OpOrNot, Name))) !(Seq (
   deriving (Show, Data, Typeable)
 data OpOrNot = Op | NonOp deriving (Eq, Show, Data, Typeable, Generic)
 instance Hashable OpOrNot
+
+-- | A list of acceptable ambiguities
+data AcceptedAmbiguity = AcceptedAmbiguity
+  { aa_range :: !Range
+  , aa_accepted :: !(Seq (Seq (Range, Name)))
+  } deriving (Show, Data)
 
 -- | A (sparse) matrix of precedences. Should only ever contain references to syncons
 -- defined as operators. Internally is a map from (min a b, max a b) names to orderings

--- a/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
@@ -6,6 +6,7 @@ module P5DynamicAmbiguity.Isolation
 , getElidableBoundsEx
 , getNodeOrElidableBoundsEx
 , Elidable
+, isAccepted
 ) where
 
 import Pre hiding (reduce, State, state, orElse)
@@ -21,7 +22,7 @@ import Text.Earley.Forest.Grammar (unlex, Parseable)
 import Text.Earley.Forest.Parser (Node)
 
 import P1Lexing.Types (Range)
-import P2LanguageDefinition.Types (TypeName(..))
+import P2LanguageDefinition.Types (TypeName(..), Name)
 import P4Parsing.Types (NodeF(NodeF), n_nameF, n_rangeF, n_beginEndF)
 import qualified P4Parsing.Types as P4
 import P5DynamicAmbiguity.Types hiding (NodeOrElide)
@@ -42,6 +43,13 @@ type IsolationM s tok a = ReaderT (State s tok) (ST s) a
 
 type FullNode = P4.Node
 type Res tok = Result (HashMap (HashSet Node) (Seq (NodeOrElide tok)))
+
+isAccepted :: HashSet (HashSet Name) -> Seq (NodeOrElide tok) -> Bool
+isAccepted accepted = foldMap getNames >>> (`S.member` accepted)
+  where
+    getNames :: NodeOrElide tok -> HashSet Name
+    getNames (Node n) = S.insert (n_nameF n) $ foldMap getNames n
+    getNames Elide{} = S.empty
 
 -- TODO: Bail out if a single ambiguity gets too large
 -- | Produce a single parse tree, or a disjoint set of minimal ambiguities.


### PR DESCRIPTION
Previously running `syncon-parser pbt --ambiguity` had little value once your language contained at least one intended ambiguity, because `pbt` would most likely find that one, which gives no new information. This PR is a first attempt to address this.

The idea is to add a new top-level construct `ambiguity`:

```
ambiguity {
  and or;
  1 2 3 4 5 6: equal notEqual lessThan greaterThan lessOrEqualThan greaterOrEqualThan;
}
```

The first line states that an ambiguity that contains exactly the syncons `and` and `or` is an intended ambiguity. Note that this interacts quite favorably with ambiguity localization, since it will localize an ambiguity to a small subtree, and additionally remove subtrees that are shared across all alternatives.

The second line is shorthand for "all subsets of size 1, 2, ..., or 6 of the set {`equal`, `notEqual`, ..., `greaterOrEqualThan`}".

I'm not yet convinced that this truly the correct approach to do this, but it is by far the best tested thus far. It is for example worth noting that saving exact ambiguities (e.g., `_ && _ || _`) and checking against those is insufficient, since it's trivial to construct an infinite number of ambiguities (e.g., `_ && _ || _ && _`). In this example we as humans can in some sense see that this is the "same" ambiguity, the larger one isn't demonstrating anything new, but I have no definition of "same" that I can truly argue strongly for.

The hypothesis right now is that there is only a single interesting ambiguity per set of syncons involved, which would then entail that we're not unintentionally accepting an ambiguity we've not yet seen, which is what I would like to avoid.

------------------------------

One final point worth mentioning: it's possible that using `ambiguity` is often redundant. The origin for the initial example looks like this in context:

```
precedence {
  nestedAccess;
  application;
  plus minus;
  equal notEqual lessThan greaterThan lessOrEqualThan greaterOrEqualThan;
  and or;
} except {
  equal notEqual lessThan greaterThan lessOrEqualThan greaterOrEqualThan;
  and or;
}

ambiguity {
  and or;
  1 2 3 4 5 6: equal notEqual lessThan greaterThan lessOrEqualThan greaterOrEqualThan;
}
```

Notably, the `except` list looks essentially the same as the `ambiguity` list. I'm not going to do this automatically at first because I'm not sure we want `except` to mean "these should be ambiguous" as opposed to "I'm not going to assign relative precedences to these."