### PR TITLE
Retain two level names

### DIFF
--- a/syncon-parser/earley-forest/src/Text/Earley/Forest/Transformations.hs
+++ b/syncon-parser/earley-forest/src/Text/Earley/Forest/Transformations.hs
@@ -33,7 +33,6 @@ import Data.STRef (STRef, newSTRef, readSTRef, modifySTRef')
 import Data.Sequence (Seq((:|>)))
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Sequence as Seq
 
 import Text.Earley.Forest.Grammar (Grammar(..), runGrammar, Prod(..), NodeKind(..))


### PR DESCRIPTION
#12 made it possible to only partially resolve an ambiguity, only resolving the shape of the root of the ambiguity. This shape consists of all structure internal to the node, as well as the covered ranges of its children. The procedure for doing this grouping discarded all other information, which made the `--two-level` flag less informative. This was especially annoying when the grouping made no difference to the suggested resolution. For example we might get an error message like this:

```
Ambiguity error with 2 alternatives.

  <Integer> == ( <Ident> - <Ident> )
  equal
   - <Integer>            <generated>:1:60-69
   - ...                  <generated>:1:73-90

  ( <Integer> == <Ident> ) - <Ident>
  minus
   - ...                  <generated>:1:60-80
   - <Ident>              <generated>:1:83-90
```

This PR fixes the issue by remembering all child names, presenting them as "a, b, or c" if there are multiple, otherwise just one:

```
Ambiguity error with 2 alternatives.

  <Integer> == ( <Ident> - <Ident> )
  equal
   - <Integer>            <generated>:1:60-69
   - minus                <generated>:1:73-90

  ( <Integer> == <Ident> ) - <Ident>
  minus
   - equal                <generated>:1:60-80
   - <Ident>              <generated>:1:83-90
```