### PR TITLE
Ensure fragments are consistent in forbidding each other

### DIFF
--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -618,7 +618,7 @@ composeCommand = Opt.command "compose" (Opt.info composeCmd $ Opt.progDesc "Crea
 
       pure $ do
         let baseID = RC.mkID base
-        info <- RC.computeInfo (base : others)
+        info <- RC.computeInfo (base : others) >>= dataOrError mempty ()
         case dirPath of
           Nothing -> RC.generateComposition count baseID info
             >>= dataOrError mempty ()


### PR DESCRIPTION
The (somewhat ad-hod) approach for random language composition present in `syncon-parser` has support for stating that if a fragment `a` is present then `b` must not be present. This has the effect of making them mutually exclusive, but previously it was rather difficult to see how such connections were made since the forbid was only present in one of the files. This PR checks that both fragments forbid each other, making it easier to see what (anti-)dependencies exist, since a corresponding forbid must now exist in both files.