### PR TITLE
Show suggestion to accept ambiguity when using --two-level

### DIFF
--- a/syncon-parser/exe/Main.hs
+++ b/syncon-parser/exe/Main.hs
@@ -227,6 +227,7 @@ parseAction = do
                 , dKind = dynAmbKind
                 , dGroupByTop = groupByTop
                 , dGetElidedTokRange = DynAmb.getElidableBoundsEx nodeMap
+                , dGetNames = DynAmb.getNames
                 }
           let checkReparse originalSize elidable replacement
                 | not reparse = True
@@ -520,6 +521,7 @@ pbtCommand = Opt.command "pbt" (Opt.info pbtCmd $ Opt.progDesc "Explore the ambi
                             , dKind = dynAmbKind
                             , dGroupByTop = groupByTop
                             , dGetElidedTokRange = DynAmb.getElidableBoundsEx nodeMap
+                            , dGetNames = DynAmb.getNames
                             }
                       let analyze' checkReparse amb = do
                             forM_ dynLogFile $ \_ -> atomicModifyIORef' dynLog (addDynMeta originalSize getBounds program amb)

--- a/syncon-parser/src/Data/Automaton/NVA.hs
+++ b/syncon-parser/src/Data/Automaton/NVA.hs
@@ -592,6 +592,7 @@ shortestUniqueWord timeoutDuration maxLength (Vec.fromList -> nvas) = do
       <&> initialConfigs
       & M.singleton []
 
+    -- OPT(vipa, 2020-10-05): the number of states appear to grow roughly exponentially. It thus seems reasonable to simulate from both edges at the same time then look for overlap between the two frontiers. I think this would have the effect of halving the exponent, which should be a sizable speedup in bad cases.
     recur :: Int  -- ^ max amount of further steps to take
           -> IORef (HashMap Int [TaggedTerminal i o c]) -- ^ already found shortest words
           -> HashMap [TaggedTerminal i o c] (Vector (HashSet (s, [sta]))) -- ^ current configurations, grouped by word so far

--- a/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
+++ b/syncon-parser/src/P5DynamicAmbiguity/Isolation.hs
@@ -7,6 +7,7 @@ module P5DynamicAmbiguity.Isolation
 , getNodeOrElidableBoundsEx
 , Elidable
 , isAccepted
+, getNames
 , AmbiguitySize
 , ambiguitySize
 ) where
@@ -48,10 +49,10 @@ type Res tok = Result (HashMap (HashSet Node) (Seq (NodeOrElide tok)))
 
 isAccepted :: HashSet (HashSet Name) -> Seq (NodeOrElide tok) -> Bool
 isAccepted accepted = foldMap getNames >>> (`S.member` accepted)
-  where
-    getNames :: NodeOrElide tok -> HashSet Name
-    getNames (Node n) = S.insert (n_nameF n) $ foldMap getNames n
-    getNames Elide{} = S.empty
+
+getNames :: NodeOrElide tok -> HashSet Name
+getNames (Node n) = S.insert (n_nameF n) $ foldMap getNames n
+getNames Elide{} = S.empty
 
 -- TODO: Bail out if a single ambiguity gets too large
 -- | Produce a single parse tree, or a disjoint set of minimal ambiguities.


### PR DESCRIPTION
This PR adds a small convenience feature, when you run with `--two-level` (which you typically do when you're designing the language and is debugging it) and you encounter a resolvable ambiguity the tool will now tell you how to accept the ambiguity.