### PR TITLE
Add a flag to generate a graphviz graph of fragments forbidding each other

### DIFF
--- a/syncon-parser/exe/RandomCompose.hs
+++ b/syncon-parser/exe/RandomCompose.hs
@@ -110,7 +110,6 @@ data ComposeState = ComposeState
 graphvizForbidGraph :: HashMap ID FileInfo -> Text
 graphvizForbidGraph infos =
   "graph {\n"
-  -- <> (M.keys infos <&> mkNode <&> (<> ";\n") & Text.concat)
   <> (toList edges <&> mkEdge <&> (<> ";\n") & Text.concat)
   <> "}\n"
   where

--- a/syncon-parser/exe/RandomCompose.hs
+++ b/syncon-parser/exe/RandomCompose.hs
@@ -4,6 +4,7 @@ module RandomCompose
 , computeInfo
 , writeAllFragmentsToDir
 , generateComposition
+, graphvizForbidGraph
 ) where
 
 import Pre hiding (state, (<.>))
@@ -105,6 +106,22 @@ data ComposeState = ComposeState
   { infos :: !(HashMap ID FileInfo)
   , pickable :: !(HashSet ID)
   }
+
+graphvizForbidGraph :: HashMap ID FileInfo -> Text
+graphvizForbidGraph infos =
+  "graph {\n"
+  -- <> (M.keys infos <&> mkNode <&> (<> ";\n") & Text.concat)
+  <> (toList edges <&> mkEdge <&> (<> ";\n") & Text.concat)
+  <> "}\n"
+  where
+    mkNode (ID id) = show id
+    mkEdge (id1, id2) = mkNode id1 <> " -- " <> mkNode id2
+    edges = toList infos
+      >>= (\FileInfo{id, forbidden} -> toList forbidden <&> (id,) <&> sortTuple)
+      & S.fromList
+    sortTuple (a, b)
+      | a < b = (a, b)
+      | otherwise = (b, a)
 
 addID :: HashSet ID -> ID -> StateT ComposeState (Result (HashSet Error)) (HashSet ID)
 addID picked id


### PR DESCRIPTION
This PR adds a convenient way to get an overview of language fragments forbidding each other by generating a graph where fragments are connected if they forbid each other.